### PR TITLE
Patch `integration-modes` link in docs.

### DIFF
--- a/get-started/introduction.mdx
+++ b/get-started/introduction.mdx
@@ -13,4 +13,4 @@ To start developing with Opkit, you must first be an Opkit customer!
   Learn more and schedule a demo
 </Card>
 
-After becoming an Opkit customer, you should consider which integration mode is appropriate for your use-case. Read [Integration Modes](/markdown/documentation/integration-modes).
+After becoming an Opkit customer, you should consider which integration mode is appropriate for your use-case. Read [Integration Modes](/get-started/integration-modes).


### PR DESCRIPTION
I was browsing Mintlify's showcase and came across your docs. Noticed a broken link in the intro. Cheer!